### PR TITLE
✨ Fix autoplay reset in LoginCarousel

### DIFF
--- a/src/components/LoginCarousel.tsx
+++ b/src/components/LoginCarousel.tsx
@@ -36,7 +36,6 @@ export default function LoginCarousel() {
 
     api.on("select", () => {
       setCurrent(api.selectedScrollSnap() + 1);
-      api.plugins.autoplay?.reset();
     });
   }, [api]);
 
@@ -47,6 +46,7 @@ export default function LoginCarousel() {
         plugins={[
           Autoplay({
             duration: 2000,
+            stopOnInteraction: false,
           }),
         ]}
         opts={{

--- a/src/components/LoginCarousel.tsx
+++ b/src/components/LoginCarousel.tsx
@@ -36,6 +36,7 @@ export default function LoginCarousel() {
 
     api.on("select", () => {
       setCurrent(api.selectedScrollSnap() + 1);
+      api.plugins.autoplay?.reset();
     });
   }, [api]);
 


### PR DESCRIPTION
Currently on the login page, if a user clicks to go to a new panel on the carousel, the auto play timer doesn't reset. This means if I go to a different panel, the carousel may immediately switch away from the one I just clicked on. 

This pull request attempts to reset the timer on interaction. 